### PR TITLE
Fix module format and naming after #62c997.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,13 @@ $ gcc -rdynamic -o test test.c
 We can then start using the [frida-agent-example](https://github.com/oleavr/frida-agent-example) as a template project and install the `stalker-coverage` module:
 ```bash
 $ npm install
-$ npm install --save stalker-coverage
+$ npm install --save ./stalker-coverage
 ```
 ## Using Stalker-Coverage
-We can then interact with this module using the following typescript code:
+We can then interact with this module using the following typescript code
+(put this in `frida-agent-example/agent/index.ts`):
 ```typescript
-import { Coverage } from "../node_modules/stalker-coverage/dist/coverage";
+import { Coverage } from "@worksbutnottested/stalker-coverage/dist/coverage";
 /*
  * This sample replaces the 'main' function of the target application with one which starts
  * collecting coverage information, before calling the original 'main' function. Once the

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "compilerOptions": {
-    "target": "esnext",
-    "lib": ["esnext"],
+    "target": "es2020",
+    "lib": ["es2020"],
     "strict": true,
-    "module": "commonjs",
     "esModuleInterop": true,
     "declaration": true,
     "outDir": "./dist",


### PR DESCRIPTION
I had some trouble getting this to work.

Here a subset of error I ran into. I tried to leave a few more breadcrumbs in the README and was able to fix the compilation and runtime errors.

frida-agent-example uses es2020 so switched this module to use the same. `commonjs` variant definitely doesn’t work anymore, so I removed it.

```
$ npm install --save stalker-coverage
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/stalker-coverage - Not found
```

```
> frida-compile agent/index.ts -o _agent.js -c

/tmp/frida-agent-example/agent/index.ts (1,26): Cannot find module '../node_modules/stalker-coverage/dist/coverage' or its corresponding type declarations.
```

```
[Frida WARNING] Failed to start: Could not load module '/node_modules/stalker-coverage/dist/coverage'
```

```
{"type":"error","description":"ReferenceError: 'exports' is not defined","stack":"ReferenceError: 'exports' is not defined\n    at <anonymous> (coverage.js:177)","fileName":"coverage.js","lineNumber":177,"columnNumber":1}
```